### PR TITLE
pvst to gml minimalistic converter

### DIFF
--- a/utils/gfa_to_gml.py
+++ b/utils/gfa_to_gml.py
@@ -1,0 +1,46 @@
+import sys
+
+def parse_tree_file(input_path):
+    node_info = {}  # maps node_id to label
+    edges = []
+    with open(input_path, 'r') as f:
+        lines = f.readlines()
+    for line in lines[1:]:  # skip header
+        parts = line.strip().split('\t')
+        if len(parts) < 4:
+            continue
+        label = parts[0].strip()
+        node_id = parts[1].strip()
+        children_field = parts[3].strip()
+        if node_id not in node_info:
+            node_info[node_id] = label
+
+        if children_field != '.':
+            children_list = [c.strip() for c in children_field.split(',') if c.strip()]
+            for child_id in children_list:
+                edges.append((node_id, child_id))
+
+    return node_info, edges
+
+def write_gml(output_path, node_info, edges):
+    with open(output_path, 'w') as g:
+        g.write("graph [\n  directed 1\n")
+        for node_id in sorted(node_info.keys(), key=lambda x: int(x) if x.isdigit() else x):
+            label = node_id
+            annotation = node_info[node_id]  # escape quotes for GML
+            g.write(f"  node [\n    id {label}\n    label \"{label}\"\n    annotation \"{annotation}\"\n  ]\n")
+        for src, dst in edges:
+            g.write(f"  edge [ source {src} target {dst} ]\n")
+        g.write("]\n")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python gfa_to_gml.py /path/to/input.txt /path/to/output.gml")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+    output_file = sys.argv[2]
+
+    node_info, edges = parse_tree_file(input_file)
+    write_gml(output_file, node_info, edges)
+    print(f"GML file written to {output_file}")

--- a/utils/pvst_to_gml.py
+++ b/utils/pvst_to_gml.py
@@ -35,7 +35,7 @@ def write_gml(output_path, node_info, edges):
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:
-        print("Usage: python gfa_to_gml.py /path/to/input.txt /path/to/output.gml")
+        print("Usage: python pvst_to_gml.py /path/to/input.pvst /path/to/output.gml")
         sys.exit(1)
 
     input_file = sys.argv[1]


### PR DESCRIPTION
- Minimal logic to converter from .pvst to .gml file format for graph visualization. 
(compatible with graphia for visualization; can install or run from: https://web.graphia.app/ )

e.g. visualising an example .pvst file -- colouring nodes in the tree based on annotations:
D: dummy node 
F: flubble
T: tiny
C: concealed
M: midi
S: smothered
O: overlap
<img width="1509" height="814" alt="Screenshot 2025-07-20 at 23 32 44" src="https://github.com/user-attachments/assets/0f0d00e1-bf82-4dca-9993-4adc212a7913" />

