### PR TITLE
Fix uninitialized variables causing crashes in Release builds

### DIFF
--- a/include/algorithms/concealed.cpp
+++ b/include/algorithms/concealed.cpp
@@ -1115,6 +1115,8 @@ void find_concealed(const pst::Tree &st, pvtr::Tree &ft, const ptu::tree_meta &t
     // pass these as arguments to the slubble functions
     fl_sls slubbles;
     slubbles.fl_v_idx = ft_v_idx;
+    slubbles.m = m;
+    slubbles.n = n;
     ai::with_ai(st, tm, slubbles.ii_adj, m, n, ai, zi, ft_v_idx);
     zi::with_ji(st, tm, slubbles.ji_adj, m, n, ai, zi, ft_v_idx);
 

--- a/include/common/types/pvst.hpp
+++ b/include/common/types/pvst.hpp
@@ -133,10 +133,13 @@ public:
 
   // ——— constructors ———
   Flubble(vt_e typ, pgt::id_or_t a, pgt::id_or_t z)
-      : VertexBase(pc::INVALID_IDX, typ), a_(a), z_(z) {}
+      : VertexBase(pc::INVALID_IDX, typ), a_(a), z_(z), 
+        ai_(pc::INVALID_IDX), zi_(pc::INVALID_IDX), 
+        m_(pc::INVALID_IDX), n_(pc::INVALID_IDX) {}
 
   Flubble(pgt::id_or_t a, pgt::id_or_t z, pt::idx_t ai, pt::idx_t zi)
-    : VertexBase(pc::INVALID_IDX, vt_e::flubble), a_(a), z_(z), ai_(ai), zi_(zi) {}
+    : VertexBase(pc::INVALID_IDX, vt_e::flubble), a_(a), z_(z), ai_(ai), zi_(zi),
+      m_(pc::INVALID_IDX), n_(pc::INVALID_IDX) {}
 
   // ——— getters ———
   pgt::id_or_t get_a() const { return this->a_; }


### PR DESCRIPTION
I was getting `std::out_of_range` exceptions when built in Release mode due to uninitialized member variables.

```shell
./bin/povu decompose -i test_data/LPA.gfa -s
terminate called after throwing an instance of 'std::out_of_range'
  what():  vector::_M_range_check: __n (which is 32564) >= this->size() (which is 7503)
[1]    12210 abort      ./bin/povu decompose -i test_data/LPA.gfa -s