### PR TITLE
Fix MidiBubble creation

### DIFF
--- a/include/graph/pvst.hpp
+++ b/include/graph/pvst.hpp
@@ -477,6 +477,10 @@ public:
   // -----------
   static MidiBubble create(pt::idx_t g_cn_idx, pgt::id_or_t g,
                            pt::idx_t s_cn_idx, pgt::id_or_t s, route_e route) {
+    // Validate indices at creation time
+    if (g_cn_idx == pc::INVALID_IDX || s_cn_idx == pc::INVALID_IDX) {
+      throw std::runtime_error("Cannot create MidiBubble with invalid indices");
+    }
     return MidiBubble(g_cn_idx, g, s_cn_idx, s, route);
   }
 
@@ -491,6 +495,10 @@ static MidiBubble parse(const route_params_t &rp) {
   // getters
   // -------
   bounds_t get_bounds() const {
+    // Safety check - should never happen
+    if (g_cn_idx_ == pc::INVALID_IDX || s_cn_idx_ == pc::INVALID_IDX) {
+      return INVALID_BOUNDS;
+    }
     return bounds_t { std::min(g_cn_idx_, s_cn_idx_), std::max(g_cn_idx_, s_cn_idx_) };
   }
   pgt::id_or_t get_g() const { return this->g_; }


### PR DESCRIPTION
Some events trigger bubble creation with uninitialized variables. But preventing thosed creation is still problematic, leading to big memory usage in the following example:

```shell
\time -v ./bin/povu gfa2vcf -i x.gfa -P GRCh38 --hairpins --hubbles -t 10
ERR [povu::misc::gen_midi_bub] [povu::misc::gen_midi_bub] Invalid MidiBubble indices: g_pvst_idx=4294967295, s_pvst_idx=28544, fst=28543, snd=28544
WARN [povu::misc::handle_fl] Failed to generate trunk MidiBubble: Cannot create MidiBubble with invalid indices
ERR [povu::misc::gen_midi_bub] [povu::misc::gen_midi_bub] Invalid MidiBubble indices: g_pvst_idx=4294967295, s_pvst_idx=28551, fst=28550, snd=28551
WARN [povu::misc::handle_fl] Failed to generate trunk MidiBubble: Cannot create MidiBubble with invalid indices
ERR [povu::misc::gen_midi_bub] [povu::misc::gen_midi_bub] Invalid MidiBubble indices: g_pvst_idx=4294967295, s_pvst_idx=28597, fst=28596, snd=28597
WARN [povu::misc::handle_fl] Failed to generate trunk MidiBubble: Cannot create MidiBubble with invalid indices
[povu::smothered::add_smothered] adding smothered [e,g] vertex: >113076<113074
[povu::smothered::add_smothered] adding smothered [e,g] vertex: >113076<113073
WARN [povu::genomics::graph::comp_walks] max steps reached for >1386>1455
WARN [povu::genomics::graph::comp_walks] max steps reached for >1388>1428

Command terminated by signal 2
Command being timed: "./bin/povu gfa2vcf -i x.gfa -P GRCh38 --hairpins --hubbles -t 10"
        User time (seconds): 247.19
        System time (seconds): 37.34
        Percent of CPU this job got: 100%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 4:44.45
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 49493484
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 16736289
        Voluntary context switches: 62
        Involuntary context switches: 3455
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0