### PR TITLE
Fix VCF output format issues

### DIFF
--- a/include/refs/refs.hpp
+++ b/include/refs/refs.hpp
@@ -194,7 +194,7 @@ class Refs {
   /* genotype data */
 
   // TODO: in C++20 or greater, use a constexpr instead of const
-  inline static const std::string BLANK_GT_VALUE = ".";
+  inline static const std::string BLANK_GT_VALUE = "0";
 
   std::vector<std::vector<std::string>> blank_genotype_cols;
 


### PR DESCRIPTION
- AC field now correctly counts per alternate allele, not per genotype
- Initialize genotypes to 0|0 for reference instead of .|.
- Track allele counts separately for ref and each unique alt allele
- Properly calculate AN as sum of all allele counts

These changes ensure VCF spec compliance where AC represents the allele count for each ALT allele in the order listed.