### PR TITLE
Expose native flubble decomposition sites

### DIFF
--- a/povu-rs/src/lib.rs
+++ b/povu-rs/src/lib.rs
@@ -49,7 +49,8 @@ pub use error::{Error, Result};
 #[cfg(feature = "ffi")]
 pub use graph::PovuGraph;
 pub use native_gfa::{
-    detect_flubble_stack, gfa_to_vcf_document, FlubbleBoundary, FlubbleCandidate, NativeGfa,
+    detect_flubble_stack, gfa_to_vcf_document, FlubbleBoundary, FlubbleCandidate,
+    FlubbleDecomposition, FlubbleSite, NativeGfa,
 };
 pub use path::{Orientation, Path, Step};
 pub use vcf::{

--- a/povu-rs/src/native_gfa.rs
+++ b/povu-rs/src/native_gfa.rs
@@ -101,6 +101,43 @@ pub struct NativeGfa {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FlubbleSite {
+    pub id: String,
+    pub parent_id: Option<String>,
+    pub level: usize,
+    pub reference_start_step: usize,
+    pub reference_end_step: usize,
+    pub start: Step,
+    pub end: Step,
+    pub is_leaf: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FlubbleDecomposition {
+    pub reference_path: String,
+    pub reference_path_index: usize,
+    pub sites: Vec<FlubbleSite>,
+}
+
+impl FlubbleDecomposition {
+    pub fn leaf_sites_bottom_up(&self) -> Vec<&FlubbleSite> {
+        let mut sites = self
+            .sites
+            .iter()
+            .filter(|site| site.is_leaf)
+            .collect::<Vec<_>>();
+        sites.sort_by_key(|site| {
+            (
+                site.reference_end_step - site.reference_start_step,
+                site.reference_start_step,
+                site.reference_end_step,
+            )
+        });
+        sites
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FlubbleCandidate {
     pub id: u64,
     pub class_id: u64,
@@ -404,6 +441,40 @@ impl NativeGfa {
                 reference.name.clone(),
                 Some(self.path_len(reference)?),
             )]))
+    }
+
+    pub fn decompose_flubbles(&self, reference_names: &[String]) -> Result<FlubbleDecomposition> {
+        let reference_idx = self.reference_path_index(reference_names)?;
+        let reference = &self.paths[reference_idx];
+        let candidates = self.candidate_sites(reference_idx);
+        let leaf_keys = leaf_site_keys(&candidates);
+        let leaf_set = leaf_keys.into_iter().collect::<HashSet<_>>();
+        let mut sites = Vec::with_capacity(candidates.len());
+
+        for (key, site) in &candidates {
+            let start = reference.steps[site.start_idx].clone();
+            let end = reference.steps[site.end_idx].clone();
+            let id = format!("{}{}", start.token(), end.token());
+            let parent_id = nearest_parent_id(&candidates, site, reference);
+            let level = nesting_level(&candidates, site);
+            sites.push(FlubbleSite {
+                id,
+                parent_id,
+                level,
+                reference_start_step: site.start_idx,
+                reference_end_step: site.end_idx,
+                start,
+                end,
+                is_leaf: leaf_set.contains(key),
+            });
+        }
+
+        sites.sort_by_key(|site| (site.reference_start_step, site.reference_end_step));
+        Ok(FlubbleDecomposition {
+            reference_path: reference.name.clone(),
+            reference_path_index: reference_idx,
+            sites,
+        })
     }
 
     fn reference_path_index(&self, reference_names: &[String]) -> Result<usize> {

--- a/povu-rs/tests/native_gfa_vcf_tests.rs
+++ b/povu-rs/tests/native_gfa_vcf_tests.rs
@@ -1,4 +1,6 @@
-use povu::{detect_flubble_stack, gfa_to_vcf, gfa_to_vcf_document, Error, FlubbleCandidate};
+use povu::{
+    detect_flubble_stack, gfa_to_vcf, gfa_to_vcf_document, Error, FlubbleCandidate, NativeGfa,
+};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -103,6 +105,61 @@ W\tHG2\t1\tchr1\t0\t3\t>0>2>3
             "HG1#1#chr1:0-3\t2\t>0>3\tC\tG\t60\tPASS\tAC=1;AF=0.5;AN=2;NS=2;AT=>1,>2;VARTYPE=SUB;TANGLED=F;ES=>0>3;LV=0\tGT\t0\t1"
         ]
     );
+}
+
+#[test]
+fn native_gfa_exposes_flubble_decomposition_sites() {
+    let gfa = "\
+H\tVN:Z:1.0
+S\t1\tA
+S\t2\tC
+S\t3\tG
+S\t4\tT
+S\t5\tAA
+S\t6\tA
+S\t7\tCCC
+L\t1\t+\t2\t+\t0M
+L\t2\t+\t3\t+\t0M
+L\t3\t+\t4\t+\t0M
+L\t2\t+\t5\t+\t0M
+L\t5\t+\t4\t+\t0M
+L\t4\t+\t6\t+\t0M
+L\t1\t+\t7\t+\t0M
+L\t7\t+\t6\t+\t0M
+P\tref\t1+,2+,3+,4+,6+\t*
+P\tinner_alt\t1+,2+,5+,4+,6+\t*
+P\touter_alt\t1+,7+,6+\t*
+";
+    let graph = NativeGfa::parse(gfa).expect("parse native GFA");
+    let decomposition = graph
+        .decompose_flubbles(&["ref".to_string()])
+        .expect("decompose flubbles");
+
+    assert_eq!(decomposition.reference_path, "ref");
+    assert_eq!(
+        decomposition
+            .sites
+            .iter()
+            .map(|site| (
+                site.id.as_str(),
+                site.parent_id.as_deref(),
+                site.level,
+                site.reference_start_step,
+                site.reference_end_step,
+                site.is_leaf,
+            ))
+            .collect::<Vec<_>>(),
+        vec![
+            (">1>6", None, 0, 0, 4, false),
+            (">2>4", Some(">1>6"), 1, 1, 3, true),
+        ]
+    );
+
+    let leaves = decomposition.leaf_sites_bottom_up();
+    assert_eq!(leaves.len(), 1);
+    assert_eq!(leaves[0].id, ">2>4");
+    assert_eq!(leaves[0].start.token(), ">2");
+    assert_eq!(leaves[0].end.token(), ">4");
 }
 
 #[test]


### PR DESCRIPTION
Expose POVU's native GFA flubble decomposition as a public Rust API so downstream tools can consume real POVU sites instead of duplicating discovery logic.\n\nValidation:\n- cargo test